### PR TITLE
feat: Add market demand percentage to user skills endpoint

### DIFF
--- a/src/main/java/com/Graduation/InstaCv/controller/ProfileController.java
+++ b/src/main/java/com/Graduation/InstaCv/controller/ProfileController.java
@@ -1,6 +1,7 @@
 package com.Graduation.InstaCv.controller;
 
 import com.Graduation.InstaCv.data.dto.ProfileDto;
+import com.Graduation.InstaCv.data.dto.response.UserSkillWithPercentageResponse;
 import com.Graduation.InstaCv.data.model.BaseSkill;
 import com.Graduation.InstaCv.data.model.User;
 import com.Graduation.InstaCv.data.model.profile.Profile;
@@ -9,6 +10,7 @@ import com.Graduation.InstaCv.data.model.profile.UserSkill;
 import com.Graduation.InstaCv.mappers.ContextAwareMapper;
 import com.Graduation.InstaCv.service.AiCvParserService;
 import com.Graduation.InstaCv.service.Interfaces.IProfileService;
+import com.Graduation.InstaCv.service.ProfileService;
 import com.Graduation.InstaCv.utils.SecurityUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,6 +27,7 @@ import java.util.Map;
 @RequestMapping(path = "/api/v1/profiles/")
 public class ProfileController {
     private final IProfileService profileService;
+    private final ProfileService concreteProfileService;
     private final ContextAwareMapper<Profile, ProfileDto, User> profileMapper;
     private final AiCvParserService aiCvParserService;
 
@@ -37,10 +40,9 @@ public class ProfileController {
     }
 
     @GetMapping("/me/skills")
-    public List<UserSkill> getSkills() {
+    public List<UserSkillWithPercentageResponse> getSkills() {
         Long userId = SecurityUtils.getCurrentUserDetails().getId();
-        Profile profile = profileService.getProfileByUserId(userId);
-        return profile.getUserSkills();
+        return concreteProfileService.getUserSkillsWithMarketDemand(userId);
     }
 
     @PostMapping("/create")

--- a/src/main/java/com/Graduation/InstaCv/data/dto/response/UserSkillWithPercentageResponse.java
+++ b/src/main/java/com/Graduation/InstaCv/data/dto/response/UserSkillWithPercentageResponse.java
@@ -1,0 +1,18 @@
+package com.Graduation.InstaCv.data.dto.response;
+
+import com.Graduation.InstaCv.data.enums.SkillLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserSkillWithPercentageResponse {
+    private Long id;
+    private String skill;
+    private SkillLevel level;
+    private Double marketDemandPercentage;
+} 

--- a/src/main/java/com/Graduation/InstaCv/repository/JobRepository.java
+++ b/src/main/java/com/Graduation/InstaCv/repository/JobRepository.java
@@ -60,4 +60,10 @@ public interface JobRepository extends JpaRepository<Job, Long> {
 
     @Query("SELECT COUNT(j) FROM Job j WHERE j.profile.user.id = :userId AND j.addDate >= :fromDate")
     long countJobsAddedAfterByUserId(@Param("userId") Long userId, @Param("fromDate") OffsetDateTime fromDate);
+
+    @Query("SELECT COUNT(DISTINCT j) FROM Job j JOIN j.jobSkills js WHERE LOWER(js.skill) = LOWER(:skillName)")
+    long countJobsContainingSkill(@Param("skillName") String skillName);
+
+    @Query("SELECT COUNT(j) FROM Job j")
+    long countAllJobs();
 }

--- a/src/main/java/com/Graduation/InstaCv/service/ProfileService.java
+++ b/src/main/java/com/Graduation/InstaCv/service/ProfileService.java
@@ -1,6 +1,7 @@
 package com.Graduation.InstaCv.service;
 
 import com.Graduation.InstaCv.data.dto.ProfileDto;
+import com.Graduation.InstaCv.data.dto.response.UserSkillWithPercentageResponse;
 import com.Graduation.InstaCv.data.model.User;
 import com.Graduation.InstaCv.data.model.github.RepoSkill;
 import com.Graduation.InstaCv.data.model.job.Job;
@@ -271,5 +272,26 @@ public class ProfileService implements IProfileService {
 
         // Save the updated profile
         profileRepository.save(profile);
+    }
+
+    public List<UserSkillWithPercentageResponse> getUserSkillsWithMarketDemand(Long userId) {
+        Profile profile = getProfileByUserId(userId);
+        List<UserSkill> userSkills = profile.getUserSkills();
+        
+        long totalJobs = jobRepository.countAllJobs();
+        
+        return userSkills.stream()
+                .map(userSkill -> {
+                    long jobsWithSkill = jobRepository.countJobsContainingSkill(userSkill.getSkill());
+                    double percentage = totalJobs > 0 ? (double) jobsWithSkill / totalJobs * 100 : 0.0;
+                    
+                    return UserSkillWithPercentageResponse.builder()
+                            .id(userSkill.getId())
+                            .skill(userSkill.getSkill())
+                            .level(userSkill.getLevel())
+                            .marketDemandPercentage(Math.round(percentage * 100.0) / 100.0) // Round to 2 decimal places
+                            .build();
+                })
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
- Create UserSkillWithPercentageResponse DTO with marketDemandPercentage field
- Add JobRepository methods to count jobs by skill and total jobs count
- Implement getUserSkillsWithMarketDemand() in ProfileService with case-insensitive skill matching
- Update /api/v1/profiles/me/skills endpoint to return skills with market demand percentages
- Calculate percentage as (jobs with skill / total jobs) * 100, rounded to 2 decimal places

This enhancement provides users with insights into job market demand for their skills.